### PR TITLE
Refactor VM hostname logic to handle unique MACs and fix first-boot restart issue

### DIFF
--- a/mac/tester15/set_hostname.sh
+++ b/mac/tester15/set_hostname.sh
@@ -1,29 +1,56 @@
 #!/bin/bash
-# This script sets the hostname based on the Mac's serial number
+# This script sets a unique, stable hostname for CI macOS VMs
+# using the last 3 octets of the primary MAC address.
+# It only runs if the hostname isn't already set correctly.
 
-SERIAL_NUMBER=$(system_profiler SPHardwareDataType | awk '/Serial Number/{print $NF}')
-HOSTNAME="mac-${SERIAL_NUMBER}"
+set -e
 
-echo "Setting system hostname to $HOSTNAME"
+# Get the primary network interface (defaults to en0)
+PRIMARY_INTERFACE=$(networksetup -listallhardwareports | \
+  awk '/Hardware Port: Wi-Fi/{getline; print $2; exit}' || echo "en0")
 
-# Apply hostname settings
+# Extract the MAC address
+MAC_ADDRESS=$(ifconfig "$PRIMARY_INTERFACE" | awk '/ether/{print $2}')
+if [[ -z "$MAC_ADDRESS" ]]; then
+    echo "❌ Could not determine MAC address for $PRIMARY_INTERFACE"
+    exit 1
+fi
+
+# Generate short unique suffix from the MAC address
+SHORT_MAC=$(echo "$MAC_ADDRESS" | awk -F: '{print $(NF-2)$(NF-1)$NF}')
+HOSTNAME="mac-${SHORT_MAC}"
+
+# Check current hostname
+CURRENT_HOSTNAME=$(scutil --get HostName 2>/dev/null || echo "")
+
+if [[ "$CURRENT_HOSTNAME" == "$HOSTNAME" ]]; then
+    echo "✅ Hostname already set correctly: $CURRENT_HOSTNAME"
+    exit 0
+fi
+
+echo "⚙️ Updating system hostname to $HOSTNAME..."
+
+# Apply hostname system-wide
 scutil --set ComputerName "$HOSTNAME"
 scutil --set LocalHostName "$HOSTNAME"
 scutil --set HostName "$HOSTNAME"
 
-# Confirm the change
-echo "New Hostname: $(scutil --get HostName)"
+# Flush caches and refresh Bonjour/mDNSResponder
+dscacheutil -flushcache
+killall -HUP mDNSResponder 2>/dev/null || true
 
-# Update /opt/worker/worker-runner-config.yaml
+# Confirm new hostname
+echo "✅ New Hostname: $(scutil --get HostName)"
+
+# Update Taskcluster worker config if it exists
 CONFIG_FILE="/opt/worker/worker-runner-config.yaml"
-
-if [ -f "$CONFIG_FILE" ]; then
-    echo "Updating worker-runner-config.yaml with new hostname..."
-    sudo sed -i.bak "s/workerID: .*/workerID: \"$HOSTNAME\"/" "$CONFIG_FILE"
-    sudo sed -i.bak "s/workerId: .*/workerId: \"$HOSTNAME\"/" "$CONFIG_FILE"
-    echo "Updated workerID and workerId in $CONFIG_FILE"
+if [[ -f "$CONFIG_FILE" ]]; then
+    echo "🛠️ Updating worker-runner-config.yaml..."
+    sudo sed -i.bak "s/^workerID:.*/workerID: \"$HOSTNAME\"/" "$CONFIG_FILE"
+    sudo sed -i.bak "s/^workerId:.*/workerId: \"$HOSTNAME\"/" "$CONFIG_FILE"
+    echo "✅ Updated worker-runner-config.yaml"
 else
-    echo "WARNING: $CONFIG_FILE not found. Skipping update."
+    echo "⚠️ No worker-runner config found at $CONFIG_FILE — skipping."
 fi
 
-echo "Hostname update complete!"
+echo "🏁 Hostname configuration complete."


### PR DESCRIPTION
Cloned Tart VMs previously shared both MAC addresses and serial numbers, which caused conflicts when running multiple instances concurrently.

Recent Tart behavior changes now ensure each clone receives a unique MAC address, removing the need for manual randomization.

This PR updates the host naming logic to:
	•	Derive the hostname from the VM’s MAC address (unique per clone)
	•	Apply the hostname immediately (no reboot required)
	•	Fix the issue where VMs needed a restart after first boot to register correctly

Overall, this simplifies VM initialization and improves reliability for multi-VM macOS worker pools.