### PR TITLE
Add path filters to tester workflow

### DIFF
--- a/.github/workflows/build-mac.yaml
+++ b/.github/workflows/build-mac.yaml
@@ -4,8 +4,14 @@ on:
   pull_request:
     branches: [ main ]
     types: [opened, synchronize, reopened]
+    paths:
+      - 'mac/tester15/**'
+      - '.github/workflows/build-mac.yaml'
   push:
     branches: [ main ]
+    paths:
+      - 'mac/tester15/**'
+      - '.github/workflows/build-mac.yaml'
   
 concurrency:
   group: ${{ github.workflow }}


### PR DESCRIPTION
## Summary
- Without path filters, any push to `main` (e.g. builder workflow changes) triggers a full tester IPSW download and VM build
- This exhausts disk on the shared runner (`macmini-m4-116`) and blocks builder builds
- Add `paths` filters so the tester only fires when tester files actually change

## Test plan
- [ ] Push a builder-only change to main and confirm tester workflow does NOT trigger
- [ ] Push a tester file change and confirm it still triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)