### PR TITLE
Reduce Puppet phase VM memory to 8GB

### DIFF
--- a/mac/builder-arm64/puppet-setup-phase1.pkr.hcl
+++ b/mac/builder-arm64/puppet-setup-phase1.pkr.hcl
@@ -27,8 +27,8 @@ variable "puppet_branch" {
 
 source "tart-cli" "puppet-setup-phase1" {
   vm_name      = var.vm_name
-  cpu_count    = 8
-  memory_gb    = 12
+  cpu_count    = 6
+  memory_gb    = 8
   disk_size_gb = 150
   ssh_password = "admin"
   ssh_username = "admin"

--- a/mac/builder-arm64/puppet-setup-phase2.pkr.hcl
+++ b/mac/builder-arm64/puppet-setup-phase2.pkr.hcl
@@ -22,8 +22,8 @@ variable "puppet_branch" {
 
 source "tart-cli" "puppet-setup-phase2" {
   vm_name      = var.vm_name
-  cpu_count    = 8
-  memory_gb    = 12
+  cpu_count    = 6
+  memory_gb    = 8
   disk_size_gb = 150
   ssh_password = "admin"
   ssh_username = "admin"


### PR DESCRIPTION
## Summary
- Build host was using 10.5GB swap with `memory_gb = 12` for the Tart VM during Puppet phases
- This caused puppet-setup-phase2 to fail with "Timeout waiting for SSH" — the VM boots so slowly under memory pressure it exceeds the 600s timeout
- Reducing to 8GB (and 6 CPUs) gives the host OS enough RAM to avoid heavy swapping

## Test plan
- [ ] Builder CI passes phase 2 without SSH timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)