### PR TITLE
Make Rosetta install non-fatal if already present in base VM

### DIFF
--- a/mac/builder-arm64/puppet-setup-phase1.pkr.hcl
+++ b/mac/builder-arm64/puppet-setup-phase1.pkr.hcl
@@ -53,7 +53,7 @@ build {
       "sudo defaults write /Library/Preferences/com.apple.commerce AutoUpdate -bool false",
 
       "echo 'Installing Rosetta 2...'",
-      "sudo softwareupdate --install-rosetta --agree-to-license",
+      "sudo softwareupdate --install-rosetta --agree-to-license || echo 'Rosetta already installed or unavailable, continuing'",
 
       "echo 'Ensuring system paths exist...'",
       "sudo mkdir -p /usr/local/bin/",


### PR DESCRIPTION
Xcode 16.4 installs Rosetta as a dependency, so the base image already has it by the time puppet-setup-phase1 runs. softwareupdate returns non-zero when there is nothing to download, causing the packer build to abort. Add || echo so the step is treated as advisory.