### PR TITLE
Add workflow_dispatch trigger to build-mac.yaml

### DIFF
--- a/.github/workflows/build-mac.yaml
+++ b/.github/workflows/build-mac.yaml
@@ -1,6 +1,7 @@
 name: Build macOS VM (PR and Main)
 
 on:
+  workflow_dispatch:
   pull_request:
     branches: [ main ]
     types: [opened, synchronize, reopened]


### PR DESCRIPTION
## Summary

Adds a `workflow_dispatch:` trigger to `build-mac.yaml` so the tester VM build can be re-run manually without pushing a commit or opening a PR.

## Why

We periodically need to rebuild the `sequoia-tester` image to pick up new ronin_puppet master state (e.g. PR #1003's deterministic cltbld password-hash fix, which the current production image predates). Without `workflow_dispatch`, the only ways to trigger a rebuild are pushing to main or touching `mac/tester15/**` — both heavier than the operation warrants.

## Side effect

Merging this PR will itself trigger a build, since `.github/workflows/build-mac.yaml` is in the path filter. That's intentional — we want a fresh `prod-latest` to deploy across the tester VM fleet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)