### PR TITLE
Use real vault + prod-latest tag when workflow_dispatch is run on main

### DIFF
--- a/.github/workflows/build-mac.yaml
+++ b/.github/workflows/build-mac.yaml
@@ -50,7 +50,7 @@ jobs:
           echo "Event: ${GITHUB_EVENT_NAME}"
           echo "Ref: ${GITHUB_REF_NAME}"
 
-          if [[ "${GITHUB_EVENT_NAME}" == "push" && "${GITHUB_REF_NAME}" == "main" ]]; then
+          if [[ ( "${GITHUB_EVENT_NAME}" == "push" || "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ) && "${GITHUB_REF_NAME}" == "main" ]]; then
             echo "Using real vault for main build"
             echo "ALIAS_TAG=prod-latest" >> $GITHUB_ENV
             echo "BUILD_TAG=prod-${GITHUB_SHA}" >> $GITHUB_ENV
@@ -67,9 +67,9 @@ jobs:
           cat $GITHUB_ENV | grep -E 'VAULT_FILE|BUILD_TAG|ALIAS_TAG' || true
           echo ""
 
-      # Stage the real vault into the workspace (only on push→main)
+      # Stage the real vault into the workspace (on push→main or workflow_dispatch→main)
       - name: Stage real vault into workspace
-        if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+        if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref_name == 'main' }}
         run: |
           # Copy from the runner's secure location into the workspace
           install -m 600 /etc/ronin/vault-real.yaml "${GITHUB_WORKSPACE}/mac/tester15/vault-real.yaml"


### PR DESCRIPTION
## Summary

PR #26 added `workflow_dispatch` as a trigger but didn't update the existing "push to main" conditionals in two places, so dispatched builds on main used the fake vault and pushed `pr-{}-latest` instead of `prod-latest`.

This PR extends both conditions to also accept `workflow_dispatch` on `main`:

1. The bash check inside `Determine vault & tags` that sets `ALIAS_TAG=prod-latest` / `BUILD_TAG=prod-${SHA}`.
2. The `if:` on `Stage real vault into workspace` that copies `/etc/ronin/vault-real.yaml` into the workspace.

## Context

We hit this on the first workflow_dispatch attempt (run 25858509879) — the build ran with the fake vault and would have produced a non-prod tag even on success. The actual failure was a transient Apple IPSW download error at 57%, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)