### PR TITLE
Bug 2049579 - Build macOS VM only from trusted refs (drop pull_request)

### DIFF
--- a/.github/workflows/build-mac.yaml
+++ b/.github/workflows/build-mac.yaml
@@ -2,18 +2,15 @@ name: Build macOS VM (PR and Main)
 
 on:
   workflow_dispatch:
-  pull_request:
-    branches: [ main ]
-    types: [opened, synchronize, reopened]
-    paths:
-      - 'mac/tester15/**'
-      - '.github/workflows/build-mac.yaml'
+  # SECURITY (Bug 2049579): do NOT trigger on pull_request. This job runs on a
+  # non-ephemeral self-hosted runner; a fork PR would execute attacker-controlled
+  # code there. Build only from trusted base-repo refs (push to main / dispatch).
   push:
     branches: [ main ]
     paths:
       - 'mac/tester15/**'
       - '.github/workflows/build-mac.yaml'
-  
+
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false


### PR DESCRIPTION
This job runs on a self-hosted runner, so it should build only from trusted base-repo refs — not `pull_request`. Switches the trigger to `push` to main / `workflow_dispatch`.

Security context is tracked in Bug 2049579 (restricted).

Follow-ups (separate): apply the same change to `build-builder-arm64.yaml` before it merges to main; ephemeralize the self-hosted runner and remove on-disk secrets from its filesystem.