### PR TITLE
build-mac.yaml: authenticate to the registry before push

### DIFF
--- a/.github/workflows/build-mac.yaml
+++ b/.github/workflows/build-mac.yaml
@@ -109,6 +109,22 @@ jobs:
           curl -fsSL http://${{ env.REGISTRY_HOST }}:${{ env.REGISTRY_PORT }}/v2/ || \
             echo "⚠️ Registry reachable but returned non-200"
 
+      # The registry now enforces authenticated push (anon pull / auth push,
+      # Bug 2049579 rec #4). Log in with the builder credential from a repo
+      # secret before pushing. Pulls (tester hosts) stay anonymous.
+      - name: Log in to the OCI registry (push)
+        if: ${{ success() }}
+        env:
+          REGISTRY: ${{ env.REGISTRY_HOST }}:${{ env.REGISTRY_PORT }}
+          REGISTRY_PUSH_PASSWORD: ${{ secrets.REGISTRY_PUSH_PASSWORD }}
+        run: |
+          if [ -z "${REGISTRY_PUSH_PASSWORD}" ]; then
+            echo "❌ REGISTRY_PUSH_PASSWORD secret not set — cannot push to the auth'd registry"
+            exit 1
+          fi
+          printf '%s' "${REGISTRY_PUSH_PASSWORD}" | tart login "${REGISTRY}" --username builder --password-stdin --insecure
+          echo "✅ logged in to ${REGISTRY} as builder"
+
       - name: Push built VM to local OCI registry
         if: ${{ success() }}
         env:


### PR DESCRIPTION
The tester registry now enforces **authenticated push** (anonymous pull / auth push — Bug 2049579 rec #4, live on m4-194). So the build must log in before `tart push`.

Adds a `tart login "$REGISTRY" --username builder --password-stdin --insecure` step using a **`REGISTRY_PUSH_PASSWORD`** repo secret (the plaintext of the htpasswd `builder` password), before the two push steps. Fails fast if the secret is unset. Tester hosts keep pulling anonymously (no change).

**Operator prereq:** add `REGISTRY_PUSH_PASSWORD` as a repo Actions secret before the next main build.

Validated: YAML parses. Verified `tart login` flags on a host (`<host> --username --password-stdin --insecure`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)