### PR TITLE
build-mac.yaml: reclaim disk + guard free space before building

### DIFF
--- a/.github/workflows/build-mac.yaml
+++ b/.github/workflows/build-mac.yaml
@@ -32,6 +32,23 @@ jobs:
       - name: Kill any stuck tart build processes
         run: pkill -9 -f "tart run sequoia-" 2>/dev/null || true
 
+      # Reclaim disk before building. The runner's Data volume has filled up
+      # historically (tart's OCI pull cache + leftover build VMs), causing builds
+      # to die mid-run. Prune the cache + any stale build VM, then fail fast if
+      # still critically low rather than producing a corrupt image.
+      - name: Reclaim disk + guard free space
+        run: |
+          echo "Disk before:"; df -h /System/Volumes/Data | tail -1
+          /opt/homebrew/bin/tart delete sequoia-tester 2>/dev/null || true
+          /opt/homebrew/bin/tart prune 2>/dev/null || true
+          echo "Disk after:";  df -h /System/Volumes/Data | tail -1
+          avail=$(df -g /System/Volumes/Data | awk 'NR==2{print $4}')
+          echo "Free: ${avail:-?} GiB"
+          if [ "${avail:-0}" -lt 30 ]; then
+            echo "::error::Only ${avail} GiB free on the runner (<30 GiB) after prune — investigate m4-116 disk before building."
+            exit 1
+          fi
+
       - name: Checkout repo
         uses: actions/checkout@v4
 


### PR DESCRIPTION
The self-hosted runner's Data volume fills up over time (tart's OCI **pull cache** + leftover build VMs), which has caused builds to die mid-run — the runner's historical flakiness. Observed **95% full / 12 GiB free on m4-116, `~/.tart` at 34 GiB**.

Adds a pre-build step that:
- deletes any stale `sequoia-tester` build VM,
- `tart prune`s the OCI cache,
- **fails fast** with a clear error if still <30 GiB free (rather than dying mid-build with a corrupt image).

Part of making the runner more resilient. Follow-ups (separate): disk/runner-offline **monitoring**, and **codifying the runner install in puppet** so a wipe/reimage is reproducible (it was hand-installed and just got `rm`'d).

Validated: YAML parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)