### PR TITLE
build host: reproducible runner install + disk prune/monitor

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,40 @@
+# macos-vms build-host scripts
+
+Operational scripts for the **build host** — the Mac that runs the self-hosted
+GitHub Actions runner and produces the `sequoia-tester` VM image
+(currently `macmini-m4-116`).
+
+## `setup-build-runner.sh`
+
+Reproducibly (re)installs the GitHub Actions self-hosted runner **and** the disk
+prune/monitor daemon. Run it whenever the runner needs to be rebuilt (host
+reimaged, runner de-registered, or config wiped) instead of reassembling the
+steps by hand.
+
+```bash
+# on the build host, as the `admin` user:
+TOKEN=$(gh api -X POST \
+  repos/mozilla-platform-ops/macos-vms/actions/runners/registration-token \
+  --jq .token)
+./setup-build-runner.sh "$TOKEN"
+```
+
+The registration token is short-lived and is passed at runtime — nothing secret
+is committed. The runner runs as a LaunchAgent in the `admin` GUI session
+(tart/Virtualization needs it), so keep `admin` autologin enabled for
+reboot-persistence.
+
+## `build-runner-maintenance.sh` + `com.mozilla.build-runner-maintenance.plist`
+
+Installed by `setup-build-runner.sh` to `/usr/local/bin` and
+`/Library/LaunchDaemons`. Runs hourly:
+
+- prunes tart's OCI pull cache (`~/.tart`, which grows unbounded) — but only
+  when no build VM is running, so it never disturbs an in-flight build;
+- emails `releng-ci-alerts@mozilla.com` (rate-limited, 6h) when free space on
+  the data volume drops below 40 GiB.
+
+This addresses the build host's historical failure mode: silently running out
+of disk and failing builds with no signal.
+
+Logs: `/var/log/build-runner-maintenance.{out,err}`.

--- a/scripts/build-runner-maintenance.sh
+++ b/scripts/build-runner-maintenance.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# build-runner-maintenance.sh — periodic disk hygiene + low-disk alerting for the
+# macos-vms build host (e.g. macmini-m4-116). Installed to /usr/local/bin and run
+# hourly by com.mozilla.build-runner-maintenance. The build host historically
+# filled its disk (tart's OCI cache in ~/.tart grows unbounded) and silently
+# started failing builds — this prunes the cache and emails when space is low.
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
+THRESHOLD_GIB=40                         # alert below this many GiB free
+ALERT_EMAIL="releng-ci-alerts@mozilla.com"
+SMTP_RELAY="smtp1.mail.mdc1.mozilla.com"
+COOLDOWN=21600                           # 6h between alerts
+STATE_FILE="/var/tmp/build-runner-maint.lastalert"
+HN="$(hostname -f 2>/dev/null || hostname)"
+
+log() { echo "$(date -u +%FT%TZ) $*"; }
+
+# 1. Prune tart's OCI pull cache — but only when no build VM is running, so we
+#    never yank an image out from under an in-flight build.
+if tart list 2>/dev/null | awk 'NR>1 && $NF=="running"{f=1} END{exit !f}'; then
+  log "a tart VM is running; skipping prune"
+else
+  tart prune 2>/dev/null && log "tart prune done" || log "tart prune skipped/failed"
+fi
+
+# 2. Check free space on the data volume and alert (rate-limited) if low.
+avail="$(df -g /System/Volumes/Data | awk 'NR==2{print $4}')"
+pct="$(df /System/Volumes/Data | awk 'NR==2{gsub(/%/,"",$5); print $5}')"
+log "disk: ${avail} GiB free (${pct}% used)"
+
+if [ "${avail:-999}" -lt "$THRESHOLD_GIB" ]; then
+  now="$(date +%s)"
+  last="$(cat "$STATE_FILE" 2>/dev/null || echo 0)"
+  if [ $(( now - last )) -ge "$COOLDOWN" ]; then
+    echo "$now" > "$STATE_FILE"
+    log "low disk (${avail} GiB < ${THRESHOLD_GIB} GiB); sending alert to ${ALERT_EMAIL}"
+    ALERT_EMAIL="$ALERT_EMAIL" SMTP_RELAY="$SMTP_RELAY" HN="$HN" \
+      AVAIL="$avail" PCT="$pct" THRESHOLD="$THRESHOLD_GIB" \
+      /usr/bin/python3 - <<'PY'
+import os, smtplib, email.utils
+msg = (
+    "From: ci-worker@mozilla.com\r\n"
+    f"To: {os.environ['ALERT_EMAIL']}\r\n"
+    f"Date: {email.utils.formatdate()}\r\n"
+    f"Subject: [build-runner] low disk on {os.environ['HN']}\r\n"
+    "\r\n"
+    f"The macos-vms build host {os.environ['HN']} has only "
+    f"{os.environ['AVAIL']} GiB free ({os.environ['PCT']}% used), below the "
+    f"{os.environ['THRESHOLD']} GiB threshold. VM builds may start failing.\r\n"
+    "Investigate: `tart list`, `du -sh ~/.tart`, and check for stuck builds.\r\n"
+)
+try:
+    s = smtplib.SMTP(os.environ["SMTP_RELAY"], 25, timeout=30)
+    s.sendmail("ci-worker@mozilla.com", os.environ["ALERT_EMAIL"], msg)
+    s.quit()
+    print("alert email sent")
+except Exception as e:
+    print(f"WARN: alert email failed: {e}")
+PY
+  else
+    log "low disk but within ${COOLDOWN}s cooldown; not re-alerting"
+  fi
+fi

--- a/scripts/com.mozilla.build-runner-maintenance.plist
+++ b/scripts/com.mozilla.build-runner-maintenance.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.mozilla.build-runner-maintenance</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/usr/local/bin/build-runner-maintenance.sh</string>
+    </array>
+    <!-- Runs as admin: tart's OCI cache lives in the admin user's ~/.tart, so
+         prune must run as that user to see and clear it. -->
+    <key>UserName</key>
+    <string>admin</string>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StartInterval</key>
+    <integer>3600</integer>
+    <key>StandardOutPath</key>
+    <string>/var/log/build-runner-maintenance.out</string>
+    <key>StandardErrorPath</key>
+    <string>/var/log/build-runner-maintenance.err</string>
+</dict>
+</plist>

--- a/scripts/setup-build-runner.sh
+++ b/scripts/setup-build-runner.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# setup-build-runner.sh — reproducibly (re)install the macos-vms GitHub Actions
+# self-hosted build runner on a build host (e.g. macmini-m4-116), plus the disk
+# prune/monitor LaunchDaemon. Turns "manual scramble after the runner is
+# wiped/de-registered" into one command.
+#
+# Run ON the build host as the `admin` user (the runner + tart builds need the
+# admin GUI session; ensure that user autologs in). Usage:
+#
+#   ./setup-build-runner.sh <registration-token>
+#
+# Get a fresh registration token (repo admin, expires ~1h):
+#   gh api -X POST repos/mozilla-platform-ops/macos-vms/actions/runners/registration-token --jq .token
+#
+# Notes:
+#   * Idempotent: re-running re-registers the runner and reinstalls the service.
+#   * The runner runs as a LaunchAgent in the admin session (tart/VZ needs it);
+#     keep admin autologin enabled so it survives reboots.
+set -euo pipefail
+
+TOKEN="${1:?usage: setup-build-runner.sh <registration-token>}"
+REPO_URL="https://github.com/mozilla-platform-ops/macos-vms"
+RUNNER_VERSION="2.335.1"
+RUNNER_DIR="${HOME}/actions-runner"
+RUNNER_NAME="$(/usr/sbin/scutil --get LocalHostName 2>/dev/null || hostname -s)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "=== 1. GitHub Actions runner (${RUNNER_VERSION}) ==="
+mkdir -p "${RUNNER_DIR}"
+cd "${RUNNER_DIR}"
+if [ ! -x ./config.sh ]; then
+  echo "downloading runner..."
+  curl -fsSLo runner.tar.gz \
+    "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-osx-arm64-${RUNNER_VERSION}.tar.gz"
+  tar xzf runner.tar.gz && rm -f runner.tar.gz
+fi
+
+# Clear any stale local registration, then register fresh. (config.sh remove
+# needs a token too; if it fails because GitHub no longer has the runner, just
+# drop the local config files — they're invalid anyway.)
+if [ -f .runner ]; then
+  ./config.sh remove --token "${TOKEN}" 2>/dev/null || rm -f .runner .credentials .credentials_rsaparams
+fi
+./config.sh --url "${REPO_URL}" --token "${TOKEN}" \
+  --labels self-hosted --unattended --name "${RUNNER_NAME}" --replace
+
+./svc.sh install
+./svc.sh start
+echo "runner service:"; ./svc.sh status || true
+
+echo "=== 2. disk prune/monitor LaunchDaemon ==="
+sudo install -m 0755 "${SCRIPT_DIR}/build-runner-maintenance.sh" /usr/local/bin/build-runner-maintenance.sh
+sudo install -m 0644 "${SCRIPT_DIR}/com.mozilla.build-runner-maintenance.plist" \
+  /Library/LaunchDaemons/com.mozilla.build-runner-maintenance.plist
+sudo chown root:wheel /Library/LaunchDaemons/com.mozilla.build-runner-maintenance.plist
+sudo launchctl bootout system /Library/LaunchDaemons/com.mozilla.build-runner-maintenance.plist 2>/dev/null || true
+sudo launchctl bootstrap system /Library/LaunchDaemons/com.mozilla.build-runner-maintenance.plist
+echo "maintenance daemon loaded (hourly prune + low-disk alert)"
+
+echo "=== done. Confirm the runner shows online:"
+echo "   gh api repos/mozilla-platform-ops/macos-vms/actions/runners --jq '.runners[].name'"


### PR DESCRIPTION
## What

Make the macos-vms self-hosted build runner (currently `macmini-m4-116`) **reproducible** and **self-maintaining**, so it stops being a hand-built single point of flakiness.

- **`scripts/setup-build-runner.sh`** — one command to (re)install the GitHub Actions runner: download v2.335.1, `config.sh` with a runtime registration token, `svc.sh install/start`, and install the maintenance daemon. Idempotent; the token is a runtime arg so **nothing secret is committed**.
- **`scripts/build-runner-maintenance.sh` + `com.mozilla.build-runner-maintenance.plist`** — hourly LaunchDaemon that prunes tart's OCI cache (`~/.tart`, grows unbounded) *only when no build VM is running*, and emails `releng-ci-alerts@mozilla.com` (rate-limited) when free space drops below 40 GiB.
- **`scripts/README.md`** — build-host ops doc.

## Why

The build host has historically failed builds by silently filling its disk (95% full when last checked), and the runner was hand-installed with no checked-in recipe — a reinstall meant reconstructing the steps from memory. This closes both gaps.

## Notes

- Complements the in-workflow disk-reclaim guard (PR #31) — that guards a single run; this keeps the host healthy between runs and makes the runner itself rebuildable.
- Runner runs as a LaunchAgent in the `admin` GUI session (tart/VZ requirement); reboot-persistence relies on `admin` autologin, documented in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)