### PR TITLE
vault-inject: reboot once so the worker picks up the real injected creds

### DIFF
--- a/mac/tester15/vault-inject.sh
+++ b/mac/tester15/vault-inject.sh
@@ -39,4 +39,21 @@ echo "installed injected vault ($(/usr/bin/wc -c < /var/root/vault.yaml | /usr/b
   https://ronin-puppet-package-repo.s3.us-west-2.amazonaws.com/macos/public/common/run-puppet.sh
 /bin/chmod +x /tmp/run-puppet.sh
 /tmp/run-puppet.sh || echo "run-puppet finished with errors (continuing)"
+
+# The generic-worker is started by cltbld's autologin session at boot, which
+# happens BEFORE this daemon finishes. So on the very first boot the worker comes
+# up reading the BAKED (fake-vault) credentials, and claimWork fails with
+# "AuthenticationFailed: Bad mac". puppet has now (re)written the worker config
+# with the REAL injected creds, but a running generic-worker doesn't re-read it.
+# Reboot ONCE so the worker restarts against the correct config; guarded by a
+# semaphore so we never reboot-loop (on every later boot the persisted config is
+# already correct, so the worker starts clean and no reboot is needed).
+REBOOT_SEM="/var/root/.vault-inject-rebooted"
+if [ ! -f "${REBOOT_SEM}" ]; then
+  /usr/bin/touch "${REBOOT_SEM}"
+  echo "first-boot injection complete — rebooting once so generic-worker picks up the real credentials"
+  echo "=== vault-inject done (pre-reboot) $(date -u +%FT%TZ) ==="
+  /sbin/reboot
+  exit 0
+fi
 echo "=== vault-inject done $(date -u +%FT%TZ) ==="


### PR DESCRIPTION
## Problem (found by the m4-235 canary)

On a freshly deployed tester VM, first boot races:
1. cltbld autologin starts generic-worker immediately — reading the **baked (fake-vault)** credentials the image shipped with.
2. *Then* `vault-inject` (this daemon) injects the real vault + runs puppet, which rewrites `worker-runner-config.yaml` with the **real** token.

But a running generic-worker doesn't re-read its config, so it keeps the stale token in `generic-worker.conf.yaml` and every `claimWork` fails:
```
AuthenticationFailed: Unauthorized: Bad mac   (method: claimWork, workerId: mac-f4a3ef)
```

Confirmed on the canary: the vault + `worker-runner-config.yaml` had the correct token (sha `e59e8d…`/44), but `generic-worker.conf.yaml` had the stale fake one (sha `1ebb41…`/41).

## Fix

After the first injection+puppet, **reboot once** so the worker restarts against the now-correct config. Semaphore-guarded (`/var/root/.vault-inject-rebooted`) so it never reboot-loops — every later boot the persisted config is already correct, so the worker starts clean and no reboot happens.

## Validation

Manual canary on m4-235 (built image → pulled → SCEP-injected vault → boot): worker hit `Bad mac` on first boot, and after exactly one reboot it **authenticated and claimed a real `mochitest-chrome` task** on `gecko-t-osx-1500-m-vms`. This automates that reboot.

Follow-up option (not needed for correctness): gate the worker LaunchAgent on the vault-inject semaphore to avoid even the one reboot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)